### PR TITLE
feat: use package.json name as serviceName by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Setup the following environment variables:
 - `PGUSER` - PostgreSQL database username
 - `PGPASSWORD` - PostgreSQL database password
 - `PGDATABASE` - PostgreSQL database name (default: `opbeans`)
-- `ELASTIC_APM_SERVICE_NAME` - Elastic APM service name for the server app
+- `ELASTIC_APM_SERVICE_NAME` - Elastic APM service name for the server
+  app (default: `opbeans-node`)
 - `ELASTIC_APM_SERVER_URL` - APM Server URL (default:
   `http://localhost:8200`)
 - `ELASTIC_APM_JS_BASE_SERVER_URL` - Elastic APM Server URL for the

--- a/server/config.js
+++ b/server/config.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var pkg = require('../package')
 var env = process.env.NODE_ENV || 'development'
 
 if (env === 'development') {
@@ -20,6 +21,8 @@ var conf = module.exports = {
   },
   redis: process.env.REDIS_URL || null,
   apm: {
+    serviceName: process.ELASTIC_APM_SERVICE_NAME || pkg.name,
+    serviceVersion: process.ELASTIC_APM_SERVICE_VERSION || pkg.version,
     active: env === 'production'
   }
 }


### PR DESCRIPTION
I manually use `ELASTIC_APM_*` if available as the default order in the agent currently is to choose the inline config over the environment variables. If I didn't do this it wouldn't be possible for people to overwrite them.