### PR TITLE
feat: add POST /api/customers endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,26 @@ npm run client-update
 
 ## Demo notes
 
-The Node.js server have a built-in bug that you can trigger by
-navigating to the path `/is-it-coffee-time`.
+### Trigger error
+
+The app have a built-in bug that you can trigger by navigating to the
+path `/is-it-coffee-time`.
+
+### Trigger slowness
+
+The app have two npm scripts for adding a new customer:
+
+- `customer-add-ok`, which will add a new customer
+- `customer-add-redos`, which fail adding a new customer and block the
+  server from processing any other requests in the meantime.
+
+Run either of the two scripts using `npm run <name>`.
+
+If running inside docker, you can run it using `docker-compose`, e.g:
+
+```
+docker-compose exec opbeans-node npm run customer-add-redos
+```
 
 ## License
 

--- a/db/customer-ok.json
+++ b/db/customer-ok.json
@@ -1,0 +1,9 @@
+{
+  "full_name": "Catherine Weaver",
+  "company_name": "Cyberdyne Systems",
+  "email": "cw@example.com",
+  "address": "18144 El Camino Real",
+  "postal_code": "5421",
+  "city": "Sunnyvale",
+  "country": "USA"
+}

--- a/db/customer-redos.json
+++ b/db/customer-redos.json
@@ -1,0 +1,9 @@
+{
+  "full_name": "Catherine Weaver",
+  "company_name": "Cyberdyne Systems",
+  "email": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!",
+  "address": "18144 El Camino Real",
+  "postal_code": "5421",
+  "city": "Sunnyvale",
+  "country": "USA"
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "client-install": "npm install --prefix client",
     "client-build": "npm run build --prefix client",
     "start": "node server.js",
-    "workload": "workload -f .workload.js"
+    "workload": "workload -f .workload.js",
+    "customer-add-ok": "curl -v -X POST -H 'Content-Type: application/json' -d @db/customer-ok.json http://localhost:3000/api/customers",
+    "customer-add-redos": "curl -v -X POST -H 'Content-Type: application/json' -d @db/customer-redos.json http://localhost:3000/api/customers"
   },
   "repository": {
     "type": "git",

--- a/server/routes.js
+++ b/server/routes.js
@@ -179,6 +179,32 @@ app.get('/customers', function (req, res) {
   })
 })
 
+app.post('/customers', function (req, res) {
+  const customer = req.body
+  const isEmail = /^([a-zA-Z0-9])(([-.]|[_]+)?([a-zA-Z0-9]+))*(@){1}[a-z0-9]+[.]{1}(([a-z]{2,3})|([a-z]{2,3}[.]{1}[a-z]{2,3}))$/
+
+  if (!customer.full_name || !customer.company_name || !isEmail.test(customer.email)) {
+    res.status(400).end()
+    return
+  }
+
+  const sql = 'INSERT INTO customers (full_name, company_name, email, address, postal_code, city, country) VALUES ($1, $2, $3, $4, $5, $6, $7)'
+  const values = [
+    customer.full_name,
+    customer.company_name,
+    customer.email,
+    customer.address,
+    customer.postal_code,
+    customer.city,
+    customer.country
+  ]
+
+  db.pool.query(sql, values, function (err) {
+    if (err) return error(err, res)
+    res.end()
+  })
+})
+
 app.get('/customers/:id', function (req, res) {
   db.pool.query('SELECT * FROM customers WHERE id=$1', [req.params.id], function (err, result) {
     if (err) return error(err, res)


### PR DESCRIPTION
The purpose of this change is to allow us to introduce a delay in the response times on demand. The new `POST /api/customers` endpoint expects a body containing a new customer (in the form of a JSON document).

Here's an example JSON document for creating a new customer:

```json
{
  "full_name": "Catherine Weaver",
  "company_name": "Cyberdyne Systems",
  "email": "cw@example.com",
  "address": "18144 El Camino Real",
  "postal_code": "5421",
  "city": "Sunnyvale",
  "country": "USA"
}
```

The code will validate that the e-mail is a valid e-mail using a regular expression. This regex however is vulnerable to a so called [ReDos](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS) attack, so if you instead of a normal e-mail like `foo@example.com`, send up the string `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!`, the regular expression will go into a very expensive loop that will make the server freeze up for a few seconds. The more `a`'s you add the the string the longer the server will freeze up. While the server is spending time trying to validate the e-mail, it can't respond to any other requests, so the overall server response time will shoot up.

This commit also adds two npm scripts:

- `customer-add-ok`, which will add a new customer
- `customer-add-redos`, which fail adding a new customer and slow down
  the server in the process

Run either of the two scripts using `npm run <name>`.