### PR TITLE
Fix worker to use startSpan instead of buildSpan

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -60,8 +60,7 @@ function performSubTasks (tasks, cb) {
 function performSubTask (name, cb) {
   if (!running) return
 
-  var span = apm.buildSpan()
-  if (span) span.start(name)
+  var span = apm.startSpan(name)
 
   setTimeout(function () {
     if (span) span.end()


### PR DESCRIPTION
The worker is still using `apm.buildSpan` for creating custom spans, but this function got deprecated in the agent version `1.1.0`. After downloading `opbeans-node` and running `npm install` it installs an agent version that is greater than `1.1.0`, thus making the application fail as follows:
```{"level":50,"time":1542028790096,"msg":"apm.buildSpan is not a function","pid":2489,"hostname":"elastica.local","type":"Error","stack":"TypeError: apm.buildSpan is not a function\n    at performSubTask (/Users/andremm/tmp/opbeans-node/worker.js:63:18)\n    at performSubTasks (/Users/andremm/tmp/opbeans-node/worker.js:52:3)\n    at Timeout.processCompletedOrder (/Users/andremm/tmp/opbeans-node/worker.js:33:3)\n    at ontimeout (timers.js:424:11)\n    at tryOnTimeout (timers.js:288:5)\n    at unrefdHandle (timers.js:508:7)\n    at Timer.processTimers (timers.js:210:12)","v":1}```
This PR makes the worker use `startSpan` instead of `buildSpan` to fix the issue.