### PR TITLE
fix: allow workload script to be disabled

### DIFF
--- a/ecosystem-workload.config.js
+++ b/ecosystem-workload.config.js
@@ -1,13 +1,21 @@
-module.exports = {
+'use strict'
+
+const config = {
   apps: [{
-    name: 'workload',
-    script: './node_modules/.bin/workload',
-    args: '-f .workload.js',
-    instances: 1,
-    restart_delay: 2000
-  }, {
     name: 'server',
     script: './server.js',
     instances: 1
   }]
 }
+
+if (process.env.WORKLOAD_DISABLED !== 'True') {
+  config.apps.push({
+    name: 'workload',
+    script: './node_modules/.bin/workload',
+    args: '-f .workload.js',
+    instances: 1,
+    restart_delay: 2000
+  })
+}
+
+module.exports = config


### PR DESCRIPTION
Depends on elastic/apm-integration-testing#490

The apm-integration-testing project will set the `WORKLOAD_DISABLED` environment variable based on the `--no-opbeans-node-loadgen` command line flag.