### PR TITLE
fix: bump Docker image node versions due random errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:12-alpine
 
 WORKDIR /app
 ADD . /app


### PR DESCRIPTION
## What does this PR do?

it would bump the Docker image Node.js version.

## Why is it important?

We have detected some issues with the 8-alpine, the http service stop working randomly the 12-alpine image does not have this issue and has a similar size.
