### PR TITLE
ci(jenkins): Trigger apm agent validation for the PRs

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -17,3 +17,5 @@
     publishers:
     - email:
         recipients: infra-root+build@elastic.co
+    periodic-folder-trigger: 1w
+    prune-dead-branches: true

--- a/.ci/jobs/opbeans-node-selector-mbp.yml
+++ b/.ci/jobs/opbeans-node-selector-mbp.yml
@@ -1,30 +1,26 @@
 ---
 - job:
-    name: apm-agent-nodejs/opbeans-node-mbp
-    display-name: Opbeans Node
-    description: Opbeans Node
+    name: apm-agent-nodejs/opbeans-node-selector-mbp
+    display-name: Opbeans Node MBP selector
+    description: Opbeans Node MBP selector
     project-type: multibranch
-    concurrent: true
-    script-path: .ci/Jenkinsfile
+    script-path: .ci/selector.groovy
     scm:
     - github:
         branch-discovery: no-pr
+        disable-pr-notifications: true
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
-        discover-tags: true
+        discover-tags: false
         repo: opbeans-node
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
-        build-strategies:
-        - tags:
-            ignore-tags-older-than: -1
-            ignore-tags-newer-than: -1
-        - regular-branches: true
-        - change-request:
-            ignore-target-only-changes: false
+        property-strategies:
+          all-branches:
+          - suppress-scm-triggering: true
         clean:
           after: true
           before: true

--- a/.ci/jobs/opbeans-node-selector-mbp.yml
+++ b/.ci/jobs/opbeans-node-selector-mbp.yml
@@ -4,6 +4,7 @@
     display-name: Opbeans Node MBP selector
     description: Opbeans Node MBP selector
     project-type: multibranch
+    concurrent: true
     script-path: .ci/selector.groovy
     scm:
     - github:

--- a/.ci/selector.groovy
+++ b/.ci/selector.groovy
@@ -1,0 +1,4 @@
+#!/usr/bin/env groovy
+@Library('apm@current') _
+
+opbeansSelectorPipeline()


### PR DESCRIPTION
### What

Enable the apm-agent PRs validation by triggering a build in the opbeans that evaluate if the consumer, aka the opbeans, behaves as expected.

### Why

Shift left to reduce failure. The current implementation does only detect issues during the release process, in fact, as a post-release operation. This will help to detect any kind of issue earlier,

### Actions
- [x] JJBB
- [x] Jenkinsfile
- [ ] Docker build changes