### PR TITLE
docker: add labels metadata

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -13,6 +13,10 @@ docker run --rm -t \
   node:12-alpine /bin/sh -c "set -x
     CI=true npm install elastic-apm-node@${AGENT_VERSION}"
 
+
+## Bump agent version in the Dockerfile
+sed -ibck "s#\(org.label-schema.version=\)\(.*\)#\1\"${AGENT_VERSION}\"#g" Dockerfile
+
 # Commit changes
-git add package.json
+git add package.json Dockerfile
 git commit -m "fix(package): bump elastic-apm-node to v${AGENT_VERSION}"

--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -15,7 +15,7 @@ docker run --rm -t \
 
 
 ## Bump agent version in the Dockerfile
-sed -ibck "s#\(org.label-schema.version=\)\(.*\)#\1\"${AGENT_VERSION}\"#g" Dockerfile
+sed -ibck "s#\(org.label-schema.version=\)\(\".*\"\)\(.*\)#\1\"${AGENT_VERSION}\"\3#g" Dockerfile
 
 # Commit changes
 git add package.json Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,13 @@ RUN npm install pm2 -g
 COPY --from=opbeans/opbeans-frontend:latest /app/build /app/client/build
 COPY --from=opbeans/opbeans-frontend:latest /app/package.json /app/client/package.json
 
+LABEL \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.vendor="Elastic" \
+    org.label-schema.name="opbeans-node" \
+    org.label-schema.version="3.6.1" \
+    org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-node" \
+    org.label-schema.vcs-url="https://github.com/elastic/opbeans-node" \
+    org.label-schema.license="MIT"
+
 CMD ["pm2-runtime", "ecosystem.config.js"]


### PR DESCRIPTION
Added some labels to easily identify what's the agent version that the opbeans is consuming, in addition to some labels that are generated for some other Elastic docker images.

### Tests

```bash
IMAGE=docker.elastic.co/observability-ci/opbeans-node:ee20db424c924c58254902a8c6501b7e242c17fe
$ docker pull ${IMAGE}
$ docker inspect ${IMAGE} | jq -r '.[0].Config.Labels'
{
  "org.label-schema.license": "MIT",
  "org.label-schema.name": "opbeans-node",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.url": "https://hub.docker.com/r/opbeans/opbeans-node",
  "org.label-schema.vcs-url": "https://github.com/elastic/opbeans-node",
  "org.label-schema.vendor": "Elastic",
  "org.label-schema.version": "3.6.1"
}
```