### PR TITLE
s/Travis CI/GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+# Lint this change with the latest node LTS.
+name: Lint
+
+# https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/2
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - run: npm install
+    - run: npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-- 'lts/*'

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-[![Build Status](https://apm-ci.elastic.co/job/apm-agent-nodejs/job/opbeans-node-mbp/job/master/badge/icon)](https://apm-ci.elastic.co/job/apm-agent-nodejs/job/opbeans-node-mbp/job/master/)
-
 # Opbeans for Node.js
 
 The Opbeans inventory management system is a demo app created and
 maintained by [Elastic](https://elastic.co).
 
-[![Build status](https://travis-ci.org/elastic/opbeans-node.svg?branch=master)](https://travis-ci.org/elastic/opbeans-node)
-[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/feross/standard)
+[![Build Status](https://apm-ci.elastic.co/job/apm-agent-nodejs/job/opbeans-node-mbp/job/master/badge/icon)](https://apm-ci.elastic.co/job/apm-agent-nodejs/job/opbeans-node-mbp/job/master/)
+[![Lint status](https://github.com/elastic/opbeans-node/workflows/Lint/badge.svg)](https://github.com/elastic/opbeans-node/actions)
 
 ## Technology Stack
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "db-setup": "./db/setup.sh",
-    "test": "standard",
+    "lint": "standard",
     "postinstall": "if [ \"$NODE_ENV\" != production ]; then npm run client-update; fi",
     "client-update": "npm run client-clone && npm run client-pull && npm run client-install && npm run client-build",
     "client-clone": "if ! [ -d client ]; then git clone https://github.com/elastic/opbeans-frontend client; fi",


### PR DESCRIPTION
The main CI system used by this repo is Jenkins. Travis, and now GH
Actions, is only used for linting.

Refs: https://github.com/elastic/apm-agent-nodejs/issues/1922
