### PR TITLE
chore: drop dotenv devDependency and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ For a complete list of PostgreSQL environment variables [see the
 official
 documentation](https://www.postgresql.org/docs/9.5/static/libpq-envars.html).
 
-In development, you can create a `.env` file in the root of the project
-containing all your secret environment variables. See
-[dotenv](https://github.com/motdotla/dotenv) for details.
-
 ## Bootstrap
 
 Populate the database with tables and basic data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -518,12 +518,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
-      "dev": true
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "workload": "^2.4.3"
   },
   "devDependencies": {
-    "dotenv": "^8.2.0",
     "standard": "^16.0.3"
   },
   "scripts": {

--- a/server/config.js
+++ b/server/config.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const pkg = require('../package')
-let env = process.env.NODE_ENV || 'development'
+const env = process.env.NODE_ENV || 'development'
 
 const conf = module.exports = {
   env: env,

--- a/server/config.js
+++ b/server/config.js
@@ -3,11 +3,6 @@
 const pkg = require('../package')
 let env = process.env.NODE_ENV || 'development'
 
-if (env === 'development') {
-  require('dotenv').config()
-  env = process.env.NODE_ENV || env // in case dotenv changes NODE_ENV
-}
-
 const conf = module.exports = {
   env: env,
   server: {


### PR DESCRIPTION
The same effect can be had by manually using one of:
    FOO=bar node ...
    env `cat my.env` node ...

* * *

The argument is simplification. One less thing to know about and one less dependabot update to handle.

Currently the opbean-node server does:

```
if (env === 'development') {
  require('dotenv').config()
  env = process.env.NODE_ENV || env // in case dotenv changes NODE_ENV
}
```

which will add env vars from a ".env" file into the running `process.env`.  The same effect can be had by any of:

1. manually adding envvars:

```
FOO=bar npm run
env FOO=bar npm run
```

2. adding them from some file:

```
% cat my.env
FOO=bar
SPAM=eggs

% env `cat my.env` node -e 'console.log(process.env)' | tail -4
   '/Library/Java/JavaVirtualMachines/jdk-15.0.1.jdk/Contents/Home',
  _: '/usr/bin/env',
  FOO: 'bar',
  SPAM: 'eggs' }
```