### PR TITLE
fix: bumping version should commit a changed package-lock.json

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -11,7 +11,7 @@ docker run --rm -t \
   -w /app \
   -v "$(pwd):/app" \
   node:12-alpine /bin/sh -c "set -x
-    CI=true npm install elastic-apm-node@${AGENT_VERSION}"
+    CI=true npm install --ignore-scripts elastic-apm-node@${AGENT_VERSION}"
 
 
 ## Bump agent version in the Dockerfile

--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -16,7 +16,8 @@ docker run --rm -t \
 
 ## Bump agent version in the Dockerfile
 sed -ibck "s#\(org.label-schema.version=\)\(\".*\"\)\(.*\)#\1\"${AGENT_VERSION}\"\3#g" Dockerfile
+rm -f Dockerfilebck
 
 # Commit changes
-git add package.json Dockerfile
+git add package.json package-lock.json Dockerfile
 git commit -m "fix(package): bump elastic-apm-node to v${AGENT_VERSION}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -710,15 +710,9 @@
       }
     },
     "elastic-apm-node": {
-<<<<<<< HEAD
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-3.31.0.tgz",
-      "integrity": "sha512-0OulazfhkXYbOaGkHncqjwOfxtcvzsDyzUKr6Y1k95HwKrjf1Vi+xPutZv4p/WfDdO+JadphI0U2Uu5ncGB2iA==",
-=======
       "version": "3.32.0",
       "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-3.32.0.tgz",
       "integrity": "sha512-6vOe1FZv5toCouuyfiXZuWNE1+1fim9zvsv7H56BKRYa7xQ3X1fxq7QAP2gLd/Z9zvSDLGNXS4DPE1eqX1A1Jw==",
->>>>>>> main
       "requires": {
         "@elastic/ecs-pino-format": "^1.2.0",
         "after-all-results": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1941,12 +1941,6 @@
         "to-source-code": "^1.0.0"
       }
     },
-    "is-negative-zero": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-      "dev": true
-    },
     "is-nil": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-nil/-/is-nil-1.0.1.tgz",
@@ -1989,15 +1983,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "is-weakref": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
-      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0"
-      }
     },
     "isexe": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,9 +141,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -712,9 +712,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elastic-apm-http-client": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/elastic-apm-http-client/-/elastic-apm-http-client-11.0.0.tgz",
-      "integrity": "sha512-HB6+O0C4GGj9k5bd6yL3QK5prGKh+Rf8Tc5iW0T7FCdh2HliICfGmB6wmdQ2XkClblLtISh7tKYgVr9YgdXl3Q==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/elastic-apm-http-client/-/elastic-apm-http-client-11.0.1.tgz",
+      "integrity": "sha512-5AOWlhs2WlZpI+DfgGqY/8Rk7KF8WeevaO8R961eBylavU6GWhLRNiJncohn5jsvrqhmeT19azBvy/oYRN7bJw==",
       "requires": {
         "agentkeepalive": "^4.2.1",
         "breadth-filter": "^2.0.0",
@@ -729,9 +729,9 @@
       }
     },
     "elastic-apm-node": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-3.30.0.tgz",
-      "integrity": "sha512-KumRBDGIE+MGgJfteAi9BDqeGxpAYpbovWjNdB5x8T3/zpnQRJkDMSblliEsMwD6uKf2+Nkxzmyq9UZdh5MbGQ==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-3.31.0.tgz",
+      "integrity": "sha512-0OulazfhkXYbOaGkHncqjwOfxtcvzsDyzUKr6Y1k95HwKrjf1Vi+xPutZv4p/WfDdO+JadphI0U2Uu5ncGB2iA==",
       "requires": {
         "@elastic/ecs-pino-format": "^1.2.0",
         "after-all-results": "^2.0.0",
@@ -740,7 +740,7 @@
         "basic-auth": "^2.0.1",
         "cookie": "^0.4.0",
         "core-util-is": "^1.0.2",
-        "elastic-apm-http-client": "11.0.0",
+        "elastic-apm-http-client": "11.0.1",
         "end-of-stream": "^1.4.4",
         "error-callsites": "^2.0.4",
         "error-stack-parser": "^2.0.6",
@@ -2026,7 +2026,8 @@
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "dev": true
     },
     "is-nil": {
       "version": "1.0.1",
@@ -2075,6 +2076,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
       "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0"
       }
@@ -2451,9 +2453,9 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.19.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+          "version": "1.19.2",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
+          "integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
@@ -2461,15 +2463,15 @@
             "get-intrinsic": "^1.1.1",
             "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
-            "has-symbols": "^1.0.2",
+            "has-symbols": "^1.0.3",
             "internal-slot": "^1.0.3",
             "is-callable": "^1.2.4",
-            "is-negative-zero": "^2.0.1",
+            "is-negative-zero": "^2.0.2",
             "is-regex": "^1.1.4",
             "is-shared-array-buffer": "^1.0.1",
             "is-string": "^1.0.7",
-            "is-weakref": "^1.0.1",
-            "object-inspect": "^1.11.0",
+            "is-weakref": "^1.0.2",
+            "object-inspect": "^1.12.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
             "string.prototype.trimend": "^1.0.4",
@@ -2477,10 +2479,20 @@
             "unbox-primitive": "^1.0.1"
           }
         },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+        },
         "is-callable": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
           "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+        },
+        "is-negative-zero": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+          "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
         },
         "is-regex": {
           "version": "1.1.4",
@@ -2497,6 +2509,14 @@
           "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
           "requires": {
             "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-weakref": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+          "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+          "requires": {
+            "call-bind": "^1.0.2"
           }
         },
         "object-inspect": {
@@ -3427,9 +3447,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1941,6 +1941,11 @@
         "to-source-code": "^1.0.0"
       }
     },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+    },
     "is-nil": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-nil/-/is-nil-1.0.1.tgz",
@@ -1983,6 +1988,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-weakref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -2350,9 +2363,9 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.19.2",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
-          "integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
@@ -2360,15 +2373,15 @@
             "get-intrinsic": "^1.1.1",
             "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
-            "has-symbols": "^1.0.3",
+            "has-symbols": "^1.0.2",
             "internal-slot": "^1.0.3",
             "is-callable": "^1.2.4",
-            "is-negative-zero": "^2.0.2",
+            "is-negative-zero": "^2.0.1",
             "is-regex": "^1.1.4",
             "is-shared-array-buffer": "^1.0.1",
             "is-string": "^1.0.7",
-            "is-weakref": "^1.0.2",
-            "object-inspect": "^1.12.0",
+            "is-weakref": "^1.0.1",
+            "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
             "string.prototype.trimend": "^1.0.4",
@@ -2376,20 +2389,10 @@
             "unbox-primitive": "^1.0.1"
           }
         },
-        "has-symbols": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
-        },
         "is-callable": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
           "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
-        },
-        "is-negative-zero": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-          "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
         },
         "is-regex": {
           "version": "1.1.4",
@@ -2406,14 +2409,6 @@
           "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
           "requires": {
             "has-tostringtag": "^1.0.0"
-          }
-        },
-        "is-weakref": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-          "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-          "requires": {
-            "call-bind": "^1.0.2"
           }
         },
         "object-inspect": {


### PR DESCRIPTION
https://github.com/elastic/opbeans-node/pull/72 added a package-lock.json to this repo to have repeatable versions.

However, the `.ci/bump-version.sh` that is run to bump the "elastic-apm-node" dependency version when a new release of the Node.js APM agent is tagged *does not commit changes to package-lock.json*.   The result is that we have a commit to the repo that *says* it has updated the elastic-apm-node dep (e.g. https://github.com/elastic/opbeans-node/commit/6ab7eba569a3b7126b1e65617320be888aaff893), but it won't actually use that newer version of the agent because package-lock.json hasn't been updated.

https://github.com/elastic/opbeans-node/pull/73 enabled dependabot on this repo. *That* will eventually create a PR to update the package-lock file. For example, in this case: https://github.com/elastic/opbeans-node/pull/146

This PR updates ".ci/bump-version.sh" to update the package-lock file. However, there is a potential issue. AFAIK there is no way to ask `npm install some-package ...` to update *only the part of package-lock.json that is relevant to just the given "some-package" argument*. Notice that the "es-abstract" dependency is updated in the PR below. This means that when a new apm-agent-nodejs.git release tag is made, we will get a commit to this repo that updates to the latest of all transitive deps. That is possibly a slight security concern.

# An alternative

An alternative would be to *not* use ".ci/bump-version.sh" and instead rely on the dependabot PR to update opbeans-node to the latest Node.js APM agent. This would mean dropping this section from the apm-agent-nodejs Jenkinsfile:
https://github.com/elastic/apm-agent-nodejs/blob/76bc0740c7b8c9140a6f58a0851767ea11970dcf/.ci/Jenkinsfile#L284-L302
It would mean we would not create tags on the opbeans-node repo. Are those needed?

Which do you prefer?
1. Get bump-version.sh to update package-lock.json, or
2. stop using bump-version.sh and rely instead on dependabot creating a PR that we can review before merging.