### PR TITLE
fix lint workflow to work with 'main' branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,10 @@ name: Lint
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   lint:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env*
 node_modules
 client
+/.vscode
 
 # For the BATS testing
 bats/


### PR DESCRIPTION
This reinstates running of the  "lint" GitHub action on PRs and commits to main, broken when we changed the default branch from "master" to "main".