### PR TITLE
Add create tag workflow

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,28 @@
+---
+# Takes the version of elastic-apm-node in the package-lock.json file and creates a tag
+# if the tag does not exist yet.
+name: create-tag
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # also fetch tags
+      - run: |
+          ELASTIC_APM_NODE_VERSION="v$(jq -r '.dependencies."elastic-apm-node".version' package-lock.json)"
+          # if the tag does not exist
+          if [[ ! $(git tag -l "${ELASTIC_APM_NODE_VERSION}") ]]; then
+            git tag ${ELASTIC_APM_NODE_VERSION}
+            git push origin "refs/tags/${ELASTIC_APM_NODE_VERSION}"
+          fi
+          


### PR DESCRIPTION
## Details
During the migration to GH Actions and upatecli in https://github.com/elastic/opbeans-node/pull/179, we forgot to replicate the behaviour of tagging the repository with the latest version.

This workflow runs on every push to `main`. If the version of `elastic-apm-node` already exists as tag, nothing will happen. Otherwise, it will create a new tag.

## Related Issues
Closes #181 