### PR TITLE
chore, ci: bump based supported node version to 14

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
         node-version: '14'
     - run: npm install

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PORT ?= 3000
 IMAGE ?= opbeans/opbeans-node
 VERSION ?= latest
-LTS_ALPINE ?= 12-alpine
+LTS_ALPINE ?= 14-alpine
 
 .DEFAULT_GOAL := help
 

--- a/docker-compose-elastic-cloud.yml
+++ b/docker-compose-elastic-cloud.yml
@@ -107,7 +107,7 @@ services:
         condition: service_healthy
 
   loadPgData:
-    image: node:12-bullseye
+    image: node:14-bullseye
     environment:
       - PGHOST=postgres
       - PGUSER=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,7 +157,7 @@ services:
         condition: service_healthy
 
   loadPgData:
-    image: node:12-bullseye
+    image: node:14-bullseye
     environment:
       - PGHOST=postgres
       - PGUSER=postgres

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "standard": "^17.0.0"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "scripts": {
     "db-setup": "./db/setup.sh",


### PR DESCRIPTION
Bumping engines to ">=14" because the opbeans-frontend is v14+ since
https://github.com/elastic/opbeans-frontend/pull/111
and there is little value in supporting older Node for this project.

Also bump v3 of actions/checkout and actions/setup-node to avoid this warning
in GH Actions CI:
    Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-node@v2.