### PR TITLE
chore(deps): bump node from 18-alpine to 20-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
Let's bump to Node.js v20, which goes LTS tomorrow.

(... instead of going to v21 -- just released in the last week or so -- from https://github.com/elastic/opbeans-node/pull/206).