### PR TITLE
ci: add dockerhub provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
       with:
         registry: docker.io
@@ -45,13 +48,15 @@ jobs:
       uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0  # v5.3.0
       with:
         context: .
+        provenance: mode=max
         push: true
+        sbom: true
         tags: ${{ steps.docker-meta.outputs.tags }}
         labels: ${{ steps.docker-meta.outputs.labels }}
 
     - name: Attest image
       uses: github-early-access/generate-build-provenance@main
       with:
-        subject-name: ${{ env.DOCKER_IMAGE_NAME }}
+        subject-name: index.docker.io/${{ env.DOCKER_IMAGE_NAME }}
         subject-digest: ${{ steps.docker-push.outputs.digest }}
-        push-to-registry: false
+        push-to-registry: true


### PR DESCRIPTION
### What

As explained in https://docs.docker.com/build/ci/github-actions/attestations/

> NOTE: When pushing to Docker Hub, please use "index.docker.io" as the registry portion of the image name.


### Issues

See https://github.com/elastic/opbeans-java/pull/271 and https://github.com/elastic/opbeans-java/pull/270