### PR TITLE
updatecli: add reverse condition

### DIFF
--- a/.ci/bump-opbeans-node.yml
+++ b/.ci/bump-opbeans-node.yml
@@ -40,6 +40,7 @@ conditions:
     name: Check if installed version differs
     kind: shell
     sourceid: elastic-apm-node
+    failwhen: true
     spec:
       command: bash .ci/scripts/test-version.sh
       environments:


### PR DESCRIPTION
### What

Condition returns 0 so it's always running even though if changes don't need to be applied.

### Why

Unfortunately, the existing shell targets are not idempotence therefore the condition is the gatekeeper. We could refactor the scripts to be idempotence as explained in the [target examples section](https://www.updatecli.io/docs/plugins/resource/shell/#_target_examples)

### Test

Given a feature branch based on `4.5.3`
```diff
diff --git a/.ci/bump-opbeans-node.yml b/.ci/bump-opbeans-node.yml
index 1ac32c4..083ad70 100644
--- a/.ci/bump-opbeans-node.yml
+++ b/.ci/bump-opbeans-node.yml
@@ -9,11 +9,11 @@ scms:
     spec:
       user: '{{ requiredEnv "GIT_USER" }}'
       email: '{{ requiredEnv "GIT_EMAIL" }}'
-      owner: elastic
+      owner: v1v
       repository: opbeans-node
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
-      branch: main
+      branch: test/updatecli
 
 actions:
   opbeans-node:

```

 When I run the script:

```bash
$  GITHUB_TOKEN=$(gh auth token) \
GIT_USER=ok GIT_EMAIL=ok@ok.com \
updatecli -c .ci/bump-opbeans-node.yml apply
```

Then it produces the expected PR: https://github.com/v1v/opbeans-node/pull/1

```
⚠ Bump elastic-apm-node to latest version:
	Source:
		✔ [elastic-apm-node] Get latest elastic-apm-node version from npm registry
	Condition:
		✔ [elastic-apm-node-version-check] Check if installed version differs
	Target:
		⚠ [dockerfile] Set org.label-schema.version in Dockerfile
		⚠ [npm] Install new elastic-apm-node npm dependency version


Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1
```


If I do the same but using the main branch (the one based on the latest version 4.5.4) then it did nothing:

```bash
...
ACTIONS
========

=============================

REPORTS:

✔ Bump elastic-apm-node to latest version:
	Source:
		✔ [elastic-apm-node] Get latest elastic-apm-node version from npm registry
	Condition:
		✗ [elastic-apm-node-version-check] Check if installed version differs
	Target:
		- [dockerfile] Set org.label-schema.version in Dockerfile
		- [npm] Install new elastic-apm-node npm dependency version


Run Summary
===========
Pipeline(s) run:
  * Changed:	0
  * Failed:	0
  * Skipped:	0
  * Succeeded:	1
```