### PR TITLE
ci: use ephemeral tokens with the required permissions

### DIFF
--- a/.github/workflows/bump-opbeans-node.yml
+++ b/.github/workflows/bump-opbeans-node.yml
@@ -22,11 +22,23 @@ jobs:
           node-version: 20
           cache: 'npm'
 
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write",
+              "pull_requests": "write"
+            }
+
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:
           command: "--experimental apply --config .ci/bump-opbeans-node.yml"
         env:
-          GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
 
       - if: failure()
         uses: elastic/oblt-actions/slack/send@v1

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -21,6 +21,17 @@ jobs:
         with:
           fetch-depth: 0 # also fetch tags
 
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write"
+            }
+
       - run: make create-release
         env:
-          GH_TOKEN: ${{ secrets.CREATE_TAG_TOKEN }}
+          GH_TOKEN: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
### What

Use https://github.com/tibdex/github-app-token to generate ephemeral tokens so we can automate:
- Update CLI
- release automation

### Why
This is the alternative to moving away from finer-grained GitHub tokens and reducing the cumbersome of rotating them as we do nowadays.

### Implementaiton details

We have used the same GitHub action in other places. I'm just trying the `permissions` flag to avoid using other permissions that require least-permissive access.

Release automation uses the ephemeral GitHub token generated by the GitHub action itself.