### PR TITLE
feat: support updatecli compose and pin versions

### DIFF
--- a/.ci/updatecli/updatecli.d/bump-opbeans-node.yml
+++ b/.ci/updatecli/updatecli.d/bump-opbeans-node.yml
@@ -8,11 +8,11 @@ scms:
     kind: github
     spec:
       user: '{{ requiredEnv "GITHUB_ACTOR" }}'
-      owner: elastic
-      repository: opbeans-node
+      owner: "{{ .scm.owner }}"
+      repository: "{{ .scm.repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
-      branch: main
+      branch: "{{ .scm.branch }}"
       commitusingapi: true
 
 actions:
@@ -26,7 +26,6 @@ actions:
       labels:
         - dependencies
         - javascript
-
 
 sources:
   elastic-apm-node:

--- a/.ci/updatecli/values.d/scm.yml
+++ b/.ci/updatecli/values.d/scm.yml
@@ -1,0 +1,10 @@
+scm:
+  enabled: true
+  owner: elastic
+  repository: opbeans-node
+  branch: main
+  commitusingapi: true
+  # begin update-compose policy values
+  user: obltmachine
+  email: obltmachine@users.noreply.github.com
+  # end update-compose policy values

--- a/.ci/updatecli/values.d/update-compose.yml
+++ b/.ci/updatecli/values.d/update-compose.yml
@@ -1,0 +1,3 @@
+spec:
+  files:
+    - "updatecli-compose.yaml"

--- a/.github/workflows/bump-opbeans-node.yml
+++ b/.github/workflows/bump-opbeans-node.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   bump:
@@ -34,9 +35,23 @@ jobs:
               "pull_requests": "write"
             }
 
+      - uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:
-          command: "--experimental apply --config .ci/bump-opbeans-node.yml"
+          command: --experimental compose diff
+          version-file: .tool-versions
+        env:
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
+
+      - uses: elastic/oblt-actions/updatecli/run@v1
+        with:
+          command: --experimental compose apply
+          version-file: .tool-versions
         env:
           GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
 

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,8 +1,5 @@
 ---
-## Workflow to periodically check if there is an available newer APM agent version, e.g.
-## "1.2.3". If so, then update to it and tag this repo with that version, e.g.
-## "v1.2.3".
-name: Bump opbeans node
+name: updatecli
 
 on:
   workflow_dispatch:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+updatecli v0.88.0

--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -1,0 +1,17 @@
+# Config file for `updatecli compose ...`.
+# https://www.updatecli.io/docs/core/compose/
+policies:
+  - name: Local Updatecli Policies
+    config:
+      - .ci/updatecli/updatecli.d/
+    values:
+      - .ci/updatecli/values.d/scm.yml
+  - name: Update Updatecli policies
+    policy: ghcr.io/updatecli/policies/autodiscovery/updatecli:0.8.0@sha256:99e9e61b501575c2c176c39f2275998d198b590a3f6b1fe829f7315f8d457e7f
+    values:
+      - .ci/updatecli/values.d/scm.yml
+      - .ci/updatecli/values.d/update-compose.yml
+  - name: Update Updatecli version
+    policy: ghcr.io/elastic/oblt-updatecli-policies/updatecli/version:0.2.0@sha256:013a37ddcdb627c46e7cba6fb9d1d7bc144584fa9063843ae7ee0f6ef26b4bea
+    values:
+      - .ci/updatecli/values.d/scm.yml


### PR DESCRIPTION
### What

Pin `updatecli` version
Use updatecli policies to bump the updatecli version.
Use updatecli policies to bump the updatecli policies.
Use updatecli policies to run the local pipelines.

### Why

Let consumers choose what updatecli version should be used.
Automate the bump for the updatecli version

### Test

https://github.com/elastic/opbeans-node/actions/runs/12165477488 created

- https://github.com/elastic/opbeans-node/pull/295
- https://github.com/elastic/opbeans-node/pull/296