### PR TITLE
chore: use CODEOWNERS instead of 'reviewers' in dependabot.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+*  @elastic/apm-agent-node-js
+/.github/workflows/  @elastic/apm-agent-node-js @elastic/observablt-ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,6 @@ updates:
       # Updating elastic-apm-node is handled by the "Update APM Agent Dep"
       # stage in the Jenkinsfile.
       - dependency-name: "elastic-apm-node"
-    reviewers:
-      - "elastic/apm-agent-node-js"
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
@@ -25,14 +23,9 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
-    reviewers:
-      - "elastic/apm-agent-node-js"
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    reviewers:
-      - "elastic/observablt-ci"
-      - "elastic/apm-agent-node-js"
     schedule:
       interval: "weekly"
       day: "sunday"


### PR DESCRIPTION
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

---

Same as was done in some other repos, e.g. https://github.com/elastic/elastic-otel-node/pull/795