### PR TITLE
Set cooldown for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       # stage in the Jenkinsfile.
       - dependency-name: "elastic-apm-node"
     cooldown:
-      days: 14
+      default-days: 14
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"


### PR DESCRIPTION
 Dependabot is configured per repo so we need your help to ensure that when “npm” is the package ecosystem that we set a cooldown to 14 days. See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown- 

